### PR TITLE
added mapping for Norm to de15 format mapping

### DIFF
--- a/assets/finc/formats/de15.json
+++ b/assets/finc/formats/de15.json
@@ -58,6 +58,7 @@
   "Nachlass": "Nachlass",
   "NaxosCD": "Audio",
   "Newspaper": "Journal, E-Journal",
+  "Norm": "Norm",
   "NotatedMusic": "Musical Score",
   "Painting": "Visual Media",
   "Photo": "Visual Media",


### PR DESCRIPTION
Currently, we would like to map Perinorm data (norms) to Intermediate Schema to be able to to do the post-processing with help of span-tag and span-export, we need a mapping for format_de15 for format "Norm" at least (to get "Norm" into format_de15 at least). I guess that this also needs to be added to further format mapping tables (all that have signed for Perinorm at least).